### PR TITLE
Fix connector to major version tag `1`

### DIFF
--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -4,4 +4,3 @@ home: https://www.twingate.com
 description: Twingate Connector helm chart
 name: connector
 version: 0.1.4
-

--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -3,4 +3,5 @@ appVersion: latest
 home: https://www.twingate.com
 description: Twingate Connector helm chart
 name: connector
-version: 0.1.3
+version: 0.1.4
+

--- a/stable/connector/values.yaml
+++ b/stable/connector/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: twingate/connector
-  tag: latest
+  tag: 1
   pullPolicy: Always
 
 resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the Connector version to our major version - `1` - so that user gets all updates to this major version but if we break compatibility and release another major version we won't break customers.
