### PR TITLE
Remove unused image pull secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
   lint-charts:
     docker:
-      - image: gcr.io/kubernetes-charts-ci/test-image:v3.4.1
+      - image: quay.io/helmpack/chart-testing:v3.4.0
     steps:
       - checkout
       - run:
           name: lint
           command: |
             ct lint --config test/ct.yaml
-            
+
   build-and-publish-charts:
     docker:
       - image: alpine/helm:3.2.4
@@ -27,7 +27,7 @@ jobs:
             - a1:6e:2f:67:a6:f3:eb:4b:5c:5f:ce:fd:25:74:ac:c1
       - run:
           name: publish
-          command: .circleci/publish.sh 
+          command: .circleci/publish.sh
 
 workflows:
   version: 2

--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: latest
 home: https://www.twingate.com
 description: Twingate Connector helm chart
 name: connector
-version: 0.1.5
+version: 0.1.6

--- a/stable/connector/README.md
+++ b/stable/connector/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the Twingate chart and 
 | `nodeSelector`                          | node labels for pod assignment                                              | `{}` (The value is evaluated as a template)             |
 | `tolerations`                           | Tolerations for pod assignment                                              | `[]` (The value is evaluated as a template)             |
 | `resources`                             | Resrouce limitations                                                        | `{}` (The value is evaluated as a template)             |
-
+| `additionalLabels`                      | Additional labels for the deployment                                        | `{}` (The value is evaluated as a template)             |
 
 
 Anti affinity to deployments ( ?? research )

--- a/stable/connector/templates/deployment.yaml
+++ b/stable/connector/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "cn.fullname" . }}
   labels:
 {{ include "cn.labels" . | indent 4 }}
+{{- if .Values.additionalLabels -}}
+  {{- toYaml .Values.additionalLabels | nindent 4 }}
+{{- end }}
 spec:
   replicas: 1
   selector:
@@ -15,6 +18,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "cn.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.additionalLabels -}}
+        {{- toYaml .Values.additionalLabels | nindent 8 }}
+        {{- end }}
     spec:
     {{- if .Values.icmpSupport.enabled }}
       securityContext:

--- a/stable/connector/templates/deployment.yaml
+++ b/stable/connector/templates/deployment.yaml
@@ -16,10 +16,6 @@ spec:
         app.kubernetes.io/name: {{ include "cn.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
     {{- if .Values.icmpSupport.enabled }}
       securityContext:
         sysctls:

--- a/stable/connector/values.yaml
+++ b/stable/connector/values.yaml
@@ -12,6 +12,8 @@ resources:
     cpu: 50m
     memory: 1G
 
+additionalLabels: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes if any
  - REMOVE: we are pulling image from the public docker registry and there are no credentials used, removing unused imagepullsecrets policy
  - ADD: adding ability to set custom labels to the deployment

#### Checklist

- [X] Chart Version bumped

