### PR TITLE
Support for passing in an existing secret

### DIFF
--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: latest
 home: https://www.twingate.com
 description: Twingate Connector helm chart
 name: connector
-version: 0.1.7
+version: 0.1.8

--- a/stable/connector/README.md
+++ b/stable/connector/README.md
@@ -27,6 +27,23 @@ These commands deploy Twingate on the Kubernetes cluster in the default configur
 
 > **Tip**: List all releases using `helm ls -n [namespace]`
 
+### Using an Existing Secret for Access/Refresh Tokens
+
+Rather than passing in `connector.accessToken` and `connector.refreshToken`, you may provide the name of an existing secret that contains those values via `connector.existingSecret`.
+
+Example secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+type: Opaque
+data:
+  TWINGATE_ACCESS_TOKEN: "your access token"
+  TWINGATE_REFRESH_TOKEN: "your refresh token"
+```
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:
@@ -45,8 +62,9 @@ The following table lists the configurable parameters of the Twingate chart and 
 |-----------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
 | `connector.network`                     | The Twingate network name, eg. acme (required)                              |                                                         |
 | `connector.url`                         | The Twingate service domain                                                 | `twingate.com`                                          |
-| `connector.accessToken`                 | Access Token (required)                                                     |                                                         |
-| `connector.refreshToken`                | Refresh Token (required)                                                    |                                                         |
+| `connector.accessToken`                 | Access Token (required unless `connector.existingSecret` is specified)      |                                                         |
+| `connector.refreshToken`                | Refresh Token (required unless `connector.existingSecret` is specified)     |                                                         |
+| `connector.existingSecret`              | The name of an existing secret to use for the access and refresh tokens     |                                                         |
 | `connector.logLevel`                    | Log Level - supported : [error, warning, info, debug]                       | `error`                                                 |
 | `connector.dnsServer`                   | Custom DNS server                                                           |                                                         |
 | `image.registry`                        | Twingate image registry                                                     | `docker.io`                                             |

--- a/stable/connector/README.md
+++ b/stable/connector/README.md
@@ -40,8 +40,8 @@ metadata:
   name: my-secret
 type: Opaque
 data:
-  TWINGATE_ACCESS_TOKEN: "your access token"
-  TWINGATE_REFRESH_TOKEN: "your refresh token"
+  TWINGATE_ACCESS_TOKEN: "your access token base64 encoded"
+  TWINGATE_REFRESH_TOKEN: "your refresh token base64 encoded"
 ```
 
 ## Uninstalling the Chart

--- a/stable/connector/templates/deployment.yaml
+++ b/stable/connector/templates/deployment.yaml
@@ -32,13 +32,17 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                {{- if .Values.connector.existingSecret }}
+                name: {{ .Values.connector.existingSecret }}
+                {{- else }}
+                name: {{ include "cn.fullname" . }}
+                {{- end }}
+                optional: false
           env:
             - name: TWINGATE_URL
               value: "https://{{ required "Network name required" .Values.connector.network }}.{{ .Values.connector.url }}"
-            - name: TWINGATE_ACCESS_TOKEN
-              value: "{{ required "Access Token required" .Values.connector.accessToken }}"
-            - name: TWINGATE_REFRESH_TOKEN
-              value: "{{ required "Refresh Token required" .Values.connector.refreshToken }}"
               {{- if .Values.connector.dnsServer }}
             - name: TWINGATE_DNS
               value: "{{ .Values.connector.dnsServer }}"

--- a/stable/connector/templates/secret.yaml
+++ b/stable/connector/templates/secret.yaml
@@ -10,6 +10,6 @@ metadata:
 {{- end }}
 type: Opaque
 data:
-  TWINGATE_ACCESS_TOKEN: "{{ required "Access Token required" .Values.connector.accessToken }}"
-  TWINGATE_REFRESH_TOKEN: "{{ required "Refresh Token required" .Values.connector.refreshToken }}"
+  TWINGATE_ACCESS_TOKEN: "{{ required "Access Token required" .Values.connector.accessToken | b64enc }}"
+  TWINGATE_REFRESH_TOKEN: "{{ required "Refresh Token required" .Values.connector.refreshToken | b64enc }}"
 {{- end -}}

--- a/stable/connector/templates/secret.yaml
+++ b/stable/connector/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.connector.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cn.fullname" . }}
+  labels:
+{{ include "cn.labels" . | indent 4 }}
+{{- if .Values.additionalLabels -}}
+  {{- toYaml .Values.additionalLabels | nindent 4 }}
+{{- end }}
+type: Opaque
+data:
+  TWINGATE_ACCESS_TOKEN: "{{ required "Access Token required" .Values.connector.accessToken }}"
+  TWINGATE_REFRESH_TOKEN: "{{ required "Refresh Token required" .Values.connector.refreshToken }}"
+{{- end -}}

--- a/stable/connector/values.yaml
+++ b/stable/connector/values.yaml
@@ -41,4 +41,5 @@ connector:
   url: "twingate.com"
   accessToken:
   refreshToken:
+  existingSecret:
   dnsServer:


### PR DESCRIPTION
#### What this PR does / why we need it:

We use GitOps to manage our Kubernetes clusters, so we store the Helm values in a Git repo. To avoid having the access/refresh tokens stored in plaintext in that repo, we need to provide an existing Secret to the deployment. We provision the secret using an operator that takes a GPG-encrypted YAML file and creates a K8S secret from it.

This is pretty common practice and can be seen in other helm charts in the wild. For example, the Bitnami redis chart: https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml#L120

While I was working on this chart, I also moved the access/refresh tokens out of the `env` into a secret (that is then mounted into the deployment). This is a bit more secure and allows RBAC measures to prevent cluster users from snooping on the token values.

#### Which issue this PR fixes if any
n/a

#### Special notes for your reviewer:
n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
