### PR TITLE
Support more than one replica.

### DIFF
--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: latest
 home: https://www.twingate.com
 description: Twingate Connector helm chart
 name: connector
-version: 0.1.8
+version: 0.1.9

--- a/stable/connector/README.md
+++ b/stable/connector/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable parameters of the Twingate chart and 
 | `affinity`                              | Map of node/pod affinities                                                  | `{}` (The value is evaluated as a template)             |
 | `nodeSelector`                          | node labels for pod assignment                                              | `{}` (The value is evaluated as a template)             |
 | `tolerations`                           | Tolerations for pod assignment                                              | `[]` (The value is evaluated as a template)             |
-| `resources`                             | Resrouce limitations                                                        | `{}` (The value is evaluated as a template)             |
+| `replicas`                              | Number of replicas in Deployment                                            | `1`                                                     |
+| `resources`                             | Resource limitations                                                        | `{}` (The value is evaluated as a template)             |
 | `additionalLabels`                      | Additional labels for the deployment                                        | `{}` (The value is evaluated as a template)             |
 | `env`                                   | Additional environment variables for the deployment                         | `{}` (The value is evaluated as a template)             |

--- a/stable/connector/templates/deployment.yaml
+++ b/stable/connector/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- toYaml .Values.additionalLabels | nindent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "cn.name" . }}

--- a/stable/connector/values.yaml
+++ b/stable/connector/values.yaml
@@ -7,6 +7,8 @@ image:
   tag: 1
   pullPolicy: Always
 
+replicas: 1
+
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
#### What this PR does / why we need it:

> For redundancy, always deploy a minimum of two Connectors per Remote Network.

Per Twingate docs, we should be able to deploy redundant Connectors with the K8S deployment, so this PR enables that.


#### Checklist

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
