### PR TITLE
Add support for specifying the number of replicas

### DIFF
--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: latest
 home: https://www.twingate.com
 description: Twingate Connector helm chart
 name: connector
-version: 0.1.10
+version: 0.1.11

--- a/stable/connector/README.md
+++ b/stable/connector/README.md
@@ -82,3 +82,4 @@ The following table lists the configurable parameters of the Twingate chart and 
 | `additionalLabels`                      | Additional labels for the deployment                                        | `{}` (The value is evaluated as a template)             |
 | `podAnnotations`                        | Map of annotations to add to pods                                           | `{}`                                                    |
 | `env`                                   | Additional environment variables for the deployment                         | `{}` (The value is evaluated as a template)             |
+| `replicas`                              | The number of instances of the connector to runment                         | `1`                                                     |

--- a/stable/connector/templates/deployment.yaml
+++ b/stable/connector/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- toYaml .Values.additionalLabels | nindent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "cn.name" . }}

--- a/stable/connector/values.yaml
+++ b/stable/connector/values.yaml
@@ -7,6 +7,8 @@ image:
   tag: 1
   pullPolicy: Always
 
+replicas: 1
+
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
What this PR does / why we need it:
Adds support for specifying the number of replicas for the connector. With this PR, the number of connectors can be specified to support failover as defined in the [docs](https://docs.twingate.com/docs/connector-best-practices)

Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

[x]  Chart Version bumped
[x]  Variables are documented in the README.md