### PR TITLE
Fix default memory resources

### DIFF
--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: latest
 home: https://www.twingate.com
 description: Twingate Connector helm chart
 name: connector
-version: 0.1.12
+version: 0.1.13

--- a/stable/connector/values.yaml
+++ b/stable/connector/values.yaml
@@ -10,7 +10,7 @@ image:
 resources:
   requests:
     cpu: 50m
-    memory: 200m
+    memory: 200Mi
 
 additionalLabels: {}
 


### PR DESCRIPTION
* Use a valid value for memory
* Fixes: Warning: spec.template.spec.containers[0].resources.requests[memory]: fractional byte value "200m" is invalid, must be an integer

#### Checklist
- [x] Chart Version bumped

