### PR TITLE
Added option for enabling hostNetwork for pod

### DIFF
--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: latest
 home: https://www.twingate.com
 description: Twingate Connector helm chart
 name: connector
-version: 0.1.14
+version: 0.1.15

--- a/stable/connector/README.md
+++ b/stable/connector/README.md
@@ -82,3 +82,4 @@ The following table lists the configurable parameters of the Twingate chart and 
 | `additionalLabels`                      | Additional labels for the deployment                                        | `{}` (The value is evaluated as a template)             |
 | `podAnnotations`                        | Map of annotations to add to pods                                           | `{}`                                                    |
 | `env`                                   | Additional environment variables for the deployment                         | `{}` (The value is evaluated as a template)             |
+| `hostNetwork`                           | Enable/Disable host network for the pods                                    | `false` (Disabled by default)

--- a/stable/connector/README.md
+++ b/stable/connector/README.md
@@ -82,4 +82,4 @@ The following table lists the configurable parameters of the Twingate chart and 
 | `additionalLabels`                      | Additional labels for the deployment                                        | `{}` (The value is evaluated as a template)             |
 | `podAnnotations`                        | Map of annotations to add to pods                                           | `{}`                                                    |
 | `env`                                   | Additional environment variables for the deployment                         | `{}` (The value is evaluated as a template)             |
-| `hostNetwork`                           | Enable/Disable host network for the pods                                    | `false` (Disabled by default)
+| `hostNetwork`                           | Enable/Disable host network for the pods                                    | `false` (Disabled by default)  |

--- a/stable/connector/templates/deployment.yaml
+++ b/stable/connector/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         - name: net.ipv4.ping_group_range
           value: "0  2147483647"
     {{- end }}
+    {{- if .Values.hostNetwork }}
+      hostNetwork: true
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/connector/values.yaml
+++ b/stable/connector/values.yaml
@@ -7,6 +7,8 @@ image:
   tag: 1
   pullPolicy: Always
 
+hostNetwork: false # To enable hostnetwork for pod
+
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
Pull Request:

Feature: Adds host network capabilities to pod
First Raised: Issue #24 

Changes: When helm template is baked, it checks if value `true` is supplied for `hostNetwork`; If yes then this will enable `hostNetwork`.

Benefits:
- Solved Issue #24 
- Helps on on-premise clusters with Custom DNS deployments
- On on-premise setups, this will help in connecting to external systems that are not part of kubernetes cluster (That's a lot of power 🔥 )