### PR TITLE
Added TWINGATE_LABEL_DEPLOYED_BY and TWINGATE_LABEL_HELM_VERSION

### DIFF
--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -4,4 +4,4 @@ home: https://www.twingate.com
 description: Twingate Connector helm chart
 icon: https://www.twingate.com/twingate.png
 name: connector
-version: 0.1.20
+version: 0.1.21

--- a/stable/connector/templates/deployment.yaml
+++ b/stable/connector/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
                 {{- end }}
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: {{ .Chart.Name }}-{{ .Chart.Version }}
             - name: TWINGATE_URL
               value: "https://{{ required "Network name required" .Values.connector.network }}.{{ .Values.connector.url | default "twingate.com" }}"
               {{- if .Values.connector.dnsServer }}

--- a/stable/connector/templates/deployment.yaml
+++ b/stable/connector/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
                 {{- end }}
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/test/golden/affinity.golden.yaml
+++ b/test/golden/affinity.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/affinity.golden.yaml
+++ b/test/golden/affinity.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/connector-url.golden.yaml
+++ b/test/golden/connector-url.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.another-twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/connector-url.golden.yaml
+++ b/test/golden/connector-url.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/default-values.golden.yaml
+++ b/test/golden/default-values.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/default-values.golden.yaml
+++ b/test/golden/default-values.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/env-vars.golden.yaml
+++ b/test/golden/env-vars.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/env-vars.golden.yaml
+++ b/test/golden/env-vars.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/extraPodDefinitions.golden.yaml
+++ b/test/golden/extraPodDefinitions.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/extraPodDefinitions.golden.yaml
+++ b/test/golden/extraPodDefinitions.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/logAnalytics.golden.yaml
+++ b/test/golden/logAnalytics.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/logAnalytics.golden.yaml
+++ b/test/golden/logAnalytics.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/loglevel-debug.golden.yaml
+++ b/test/golden/loglevel-debug.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-debug.golden.yaml
+++ b/test/golden/loglevel-debug.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/loglevel-error.golden.yaml
+++ b/test/golden/loglevel-error.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-error.golden.yaml
+++ b/test/golden/loglevel-error.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/loglevel-info.golden.yaml
+++ b/test/golden/loglevel-info.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-info.golden.yaml
+++ b/test/golden/loglevel-info.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/loglevel-warning.golden.yaml
+++ b/test/golden/loglevel-warning.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-warning.golden.yaml
+++ b/test/golden/loglevel-warning.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/resources.golden.yaml
+++ b/test/golden/resources.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/resources.golden.yaml
+++ b/test/golden/resources.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21

--- a/test/golden/toleration.golden.yaml
+++ b/test/golden/toleration.golden.yaml
@@ -45,6 +45,10 @@ spec:
                 name: test-connector
                 optional: false
           env:
+            - name: TWINGATE_LABEL_DEPLOYEDBY
+              value: helm
+            - name: TWINGATE_LABEL_HELM_CHART
+              value: connector-0.1.21
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/toleration.golden.yaml
+++ b/test/golden/toleration.golden.yaml
@@ -45,7 +45,7 @@ spec:
                 name: test-connector
                 optional: false
           env:
-            - name: TWINGATE_LABEL_DEPLOYEDBY
+            - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
               value: connector-0.1.21


### PR DESCRIPTION
#### What this PR does / why we need it:
- Added `TWINGATE_LABEL_DEPLOYED_BY` and `TWINGATE_LABEL_HELM_VERSION` labels to connector deployment

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
