### PR TITLE
Fix golden tests to be stable when chart version changes

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.20.3
+golang 1.21.0

--- a/golden_test.go
+++ b/golden_test.go
@@ -1,62 +1,62 @@
 package golden
 
 import (
-	"flag"
-	"fmt"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"testing"
+    "flag"
+    "fmt"
+    "os"
+    "path/filepath"
+    "regexp"
+    "strings"
+    "testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
+    "github.com/gruntwork-io/terratest/modules/helm"
 )
 
 var update = flag.Bool("update", false, "update golden test output files")
 
 func TestHelmRender(t *testing.T) {
-	files, err := os.ReadDir("./test/golden")
-	if err != nil {
-		t.Fatal(err)
-	}
+    files, err := os.ReadDir("./test/golden")
+    if err != nil {
+        t.Fatal(err)
+    }
 
-	for _, f := range files {
-		if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
-			// Render this values.yaml file
-			output := helm.RenderTemplate(t,
-				&helm.Options{
-					ValuesFiles: []string{"test/golden/" + f.Name()},
-					SetValues: map[string]string{
-						"versionOverrideForTests": "0.0.0-test",
-					},
-				},
-				"./stable/connector",
-				"test",
-				nil,
-			)
+    for _, f := range files {
+        if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
+            // Render this values.yaml file
+            output := helm.RenderTemplate(t,
+                &helm.Options{
+                    ValuesFiles: []string{"test/golden/" + f.Name()},
+                    SetValues: map[string]string{
+                        "versionOverrideForTests": "0.0.0-test",
+                    },
+                },
+                "./stable/connector",
+                "test",
+                nil,
+            )
 
-			goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
-			regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
-			bytes := regex.ReplaceAll([]byte(output), []byte(""))
+            goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
+            regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
+            bytes := regex.ReplaceAll([]byte(output), []byte(""))
 
-			output = fmt.Sprintf("%s\n", string(bytes))
+            output = fmt.Sprintf("%s\n", string(bytes))
 
-			if *update {
-				err := os.WriteFile(goldenFile, []byte(output), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
+            if *update {
+                err := os.WriteFile(goldenFile, []byte(output), 0644)
+                if err != nil {
+                    t.Fatal(err)
+                }
+            }
 
-			expected, err := os.ReadFile(goldenFile)
-			if err != nil {
-				t.Fatal(err)
-			}
+            expected, err := os.ReadFile(goldenFile)
+            if err != nil {
+                t.Fatal(err)
+            }
 
-			if string(expected) != output {
-				t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
-			}
-		}
+            if string(expected) != output {
+                t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
+            }
+        }
 
-	}
+    }
 }

--- a/golden_test.go
+++ b/golden_test.go
@@ -1,83 +1,83 @@
 package golden
 
 import (
-	"flag"
-	"fmt"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"testing"
+    "flag"
+    "fmt"
+    "os"
+    "path/filepath"
+    "regexp"
+    "strings"
+    "testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"gopkg.in/yaml.v2"
+    "github.com/gruntwork-io/terratest/modules/helm"
+    "gopkg.in/yaml.v2"
 )
 
 var update = flag.Bool("update", false, "update golden test output files")
 
 type ChartYaml struct {
-	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
+    Name    string `yaml:"name"`
+    Version string `yaml:"version"`
 }
 
 func GetChartYaml(t *testing.T) ChartYaml {
-	chartYamlFile, err := os.ReadFile("./stable/connector/Chart.yaml")
-	if err != nil {
-		t.Fatalf("Error reading Chart.yaml: %v", err)
-	}
+    chartYamlFile, err := os.ReadFile("./stable/connector/Chart.yaml")
+    if err != nil {
+        t.Fatalf("Error reading Chart.yaml: %v", err)
+    }
 
-	var chartYaml ChartYaml
+    var chartYaml ChartYaml
 
-	if err := yaml.Unmarshal(chartYamlFile, &chartYaml); err != nil {
-		t.Fatalf("Error unmarshaling YAML data: %v", err)
-	}
+    if err := yaml.Unmarshal(chartYamlFile, &chartYaml); err != nil {
+        t.Fatalf("Error unmarshaling YAML data: %v", err)
+    }
 
-	return chartYaml
+    return chartYaml
 }
 
 func TestHelmRender(t *testing.T) {
-	files, err := os.ReadDir("./test/golden")
-	if err != nil {
-		t.Fatal(err)
-	}
+    files, err := os.ReadDir("./test/golden")
+    if err != nil {
+        t.Fatal(err)
+    }
 
-	chartYaml := GetChartYaml(t)
+    chartYaml := GetChartYaml(t)
 
-	for _, f := range files {
-		if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
-			// Render this values.yaml file
-			output := helm.RenderTemplate(t,
-				&helm.Options{
-					ValuesFiles: []string{"test/golden/" + f.Name()},
-				},
-				"./stable/connector",
-				"test",
-				nil,
-			)
+    for _, f := range files {
+        if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
+            // Render this values.yaml file
+            output := helm.RenderTemplate(t,
+                &helm.Options{
+                    ValuesFiles: []string{"test/golden/" + f.Name()},
+                },
+                "./stable/connector",
+                "test",
+                nil,
+            )
 
-			goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
+            goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
 
-			// Replace `cn.chart` helper value with a stable value for testing
-			regex := regexp.MustCompile(fmt.Sprintf("%s-%s", chartYaml.Name, chartYaml.Version))
-			bytes := regex.ReplaceAll([]byte(output), []byte("major.minor.patch-test"))
-			output = fmt.Sprintf("%s\n", string(bytes))
+            // Replace `cn.chart` helper value with a stable value for testing
+            regex := regexp.MustCompile(fmt.Sprintf("%s-%s", chartYaml.Name, chartYaml.Version))
+            bytes := regex.ReplaceAll([]byte(output), []byte(fmt.Sprintf("%s-major.minor.patch-test", chartYaml.Name)))
+            output = fmt.Sprintf("%s\n", string(bytes))
 
-			if *update {
-				err := os.WriteFile(goldenFile, []byte(output), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
+            if *update {
+                err := os.WriteFile(goldenFile, []byte(output), 0644)
+                if err != nil {
+                    t.Fatal(err)
+                }
+            }
 
-			expected, err := os.ReadFile(goldenFile)
-			if err != nil {
-				t.Fatal(err)
-			}
+            expected, err := os.ReadFile(goldenFile)
+            if err != nil {
+                t.Fatal(err)
+            }
 
-			if string(expected) != output {
-				t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
-			}
-		}
+            if string(expected) != output {
+                t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
+            }
+        }
 
-	}
+    }
 }

--- a/golden_test.go
+++ b/golden_test.go
@@ -1,83 +1,83 @@
 package golden
 
 import (
-    "flag"
-    "fmt"
-    "os"
-    "path/filepath"
-    "regexp"
-    "strings"
-    "testing"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
 
-    "github.com/gruntwork-io/terratest/modules/helm"
-    "gopkg.in/yaml.v2"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"gopkg.in/yaml.v2"
 )
 
 var update = flag.Bool("update", false, "update golden test output files")
 
 type ChartYaml struct {
-    Name    string `yaml:"name"`
-    Version string `yaml:"version"`
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
 }
 
 func GetChartYaml(t *testing.T) ChartYaml {
-    chartYamlFile, err := os.ReadFile("./stable/connector/Chart.yaml")
-    if err != nil {
-        t.Fatalf("Error reading Chart.yaml: %v", err)
-    }
+	chartYamlFile, err := os.ReadFile("./stable/connector/Chart.yaml")
+	if err != nil {
+		t.Fatalf("Error reading Chart.yaml: %v", err)
+	}
 
-    var chartYaml ChartYaml
+	var chartYaml ChartYaml
 
-    if err := yaml.Unmarshal(chartYamlFile, &chartYaml); err != nil {
-        t.Fatalf("Error unmarshaling YAML data: %v", err)
-    }
+	if err := yaml.Unmarshal(chartYamlFile, &chartYaml); err != nil {
+		t.Fatalf("Error unmarshaling YAML data: %v", err)
+	}
 
-    return chartYaml
+	return chartYaml
 }
 
 func TestHelmRender(t *testing.T) {
-    files, err := os.ReadDir("./test/golden")
-    if err != nil {
-        t.Fatal(err)
-    }
+	files, err := os.ReadDir("./test/golden")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    chartYaml := GetChartYaml(t)
+	chartYaml := GetChartYaml(t)
 
-    for _, f := range files {
-        if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
-            // Render this values.yaml file
-            output := helm.RenderTemplate(t,
-                &helm.Options{
-                    ValuesFiles: []string{"test/golden/" + f.Name()},
-                },
-                "./stable/connector",
-                "test",
-                nil,
-            )
+	for _, f := range files {
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
+			// Render this values.yaml file
+			output := helm.RenderTemplate(t,
+				&helm.Options{
+					ValuesFiles: []string{"test/golden/" + f.Name()},
+				},
+				"./stable/connector",
+				"test",
+				nil,
+			)
 
-            goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
+			goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
 
-            // Replace `cn.chart` helper value with a stable value for testing
-            regex := regexp.MustCompile(fmt.Sprintf("%s-%s", chartYaml.Name, chartYaml.Version))
-            bytes := regex.ReplaceAll([]byte(output), []byte("major.minor.patch-test"))
-            output = fmt.Sprintf("%s\n", string(bytes))
+			// Replace `cn.chart` helper value with a stable value for testing
+			regex := regexp.MustCompile(fmt.Sprintf("%s-%s", chartYaml.Name, chartYaml.Version))
+			bytes := regex.ReplaceAll([]byte(output), []byte("major.minor.patch-test"))
+			output = fmt.Sprintf("%s\n", string(bytes))
 
-            if *update {
-                err := os.WriteFile(goldenFile, []byte(output), 0644)
-                if err != nil {
-                    t.Fatal(err)
-                }
-            }
+			if *update {
+				err := os.WriteFile(goldenFile, []byte(output), 0644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
 
-            expected, err := os.ReadFile(goldenFile)
-            if err != nil {
-                t.Fatal(err)
-            }
+			expected, err := os.ReadFile(goldenFile)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-            if string(expected) != output {
-                t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
-            }
-        }
+			if string(expected) != output {
+				t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
+			}
+		}
 
-    }
+	}
 }

--- a/golden_test.go
+++ b/golden_test.go
@@ -10,50 +10,74 @@ import (
     "testing"
 
     "github.com/gruntwork-io/terratest/modules/helm"
+    "gopkg.in/yaml.v2"
 )
 
 var update = flag.Bool("update", false, "update golden test output files")
 
+type ChartYaml struct {
+    Name    string `yaml:"name"`
+    Version string `yaml:"version"`
+}
+
+func GetChartYaml(t *testing.T) ChartYaml {
+    chartYamlFile, err := os.ReadFile("./stable/connector/Chart.yaml")
+    if err != nil {
+        t.Fatalf("Error reading Chart.yaml: %v", err)
+    }
+
+    var chartYaml ChartYaml
+
+    if err := yaml.Unmarshal(chartYamlFile, &chartYaml); err != nil {
+        t.Fatalf("Error unmarshaling YAML data: %v", err)
+    }
+
+    return chartYaml
+}
+
 func TestHelmRender(t *testing.T) {
-	files, err := os.ReadDir("./test/golden")
-	if err != nil {
-		t.Fatal(err)
-	}
+    files, err := os.ReadDir("./test/golden")
+    if err != nil {
+        t.Fatal(err)
+    }
 
-	for _, f := range files {
-		if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
-			// Render this values.yaml file
-			output := helm.RenderTemplate(t,
-				&helm.Options{
-					ValuesFiles: []string{"test/golden/" + f.Name()},
-				},
-				"./stable/connector",
-				"test",
-				nil,
-			)
+    chartYaml := GetChartYaml(t)
 
-			goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
-			regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
-			bytes := regex.ReplaceAll([]byte(output), []byte(""))
+    for _, f := range files {
+        if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
+            // Render this values.yaml file
+            output := helm.RenderTemplate(t,
+                &helm.Options{
+                    ValuesFiles: []string{"test/golden/" + f.Name()},
+                },
+                "./stable/connector",
+                "test",
+                nil,
+            )
 
-			output = fmt.Sprintf("%s\n", string(bytes))
+            goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
 
-			if *update {
-				err := os.WriteFile(goldenFile, []byte(output), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
+            // Replace `cn.chart` helper value with a stable value for testing
+            regex := regexp.MustCompile(fmt.Sprintf("%s-%s", chartYaml.Name, chartYaml.Version))
+            bytes := regex.ReplaceAll([]byte(output), []byte("major.minor.patch-test"))
+            output = fmt.Sprintf("%s\n", string(bytes))
 
-			expected, err := os.ReadFile(goldenFile)
-			if err != nil {
-				t.Fatal(err)
-			}
+            if *update {
+                err := os.WriteFile(goldenFile, []byte(output), 0644)
+                if err != nil {
+                    t.Fatal(err)
+                }
+            }
 
-			if string(expected) != output {
-				t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
-			}
-		}
+            expected, err := os.ReadFile(goldenFile)
+            if err != nil {
+                t.Fatal(err)
+            }
 
-	}
+            if string(expected) != output {
+                t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
+            }
+        }
+
+    }
 }

--- a/golden_test.go
+++ b/golden_test.go
@@ -15,48 +15,45 @@ import (
 var update = flag.Bool("update", false, "update golden test output files")
 
 func TestHelmRender(t *testing.T) {
-    files, err := os.ReadDir("./test/golden")
-    if err != nil {
-        t.Fatal(err)
-    }
+	files, err := os.ReadDir("./test/golden")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    for _, f := range files {
-        if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
-            // Render this values.yaml file
-            output := helm.RenderTemplate(t,
-                &helm.Options{
-                    ValuesFiles: []string{"test/golden/" + f.Name()},
-                    SetValues: map[string]string{
-                        "versionOverrideForTests": "0.0.0-test",
-                    },
-                },
-                "./stable/connector",
-                "test",
-                nil,
-            )
+	for _, f := range files {
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
+			// Render this values.yaml file
+			output := helm.RenderTemplate(t,
+				&helm.Options{
+					ValuesFiles: []string{"test/golden/" + f.Name()},
+				},
+				"./stable/connector",
+				"test",
+				nil,
+			)
 
-            goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
-            regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
-            bytes := regex.ReplaceAll([]byte(output), []byte(""))
+			goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
+			regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
+			bytes := regex.ReplaceAll([]byte(output), []byte(""))
 
-            output = fmt.Sprintf("%s\n", string(bytes))
+			output = fmt.Sprintf("%s\n", string(bytes))
 
-            if *update {
-                err := os.WriteFile(goldenFile, []byte(output), 0644)
-                if err != nil {
-                    t.Fatal(err)
-                }
-            }
+			if *update {
+				err := os.WriteFile(goldenFile, []byte(output), 0644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
 
-            expected, err := os.ReadFile(goldenFile)
-            if err != nil {
-                t.Fatal(err)
-            }
+			expected, err := os.ReadFile(goldenFile)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-            if string(expected) != output {
-                t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
-            }
-        }
+			if string(expected) != output {
+				t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
+			}
+		}
 
-    }
+	}
 }

--- a/golden_test.go
+++ b/golden_test.go
@@ -15,45 +15,48 @@ import (
 var update = flag.Bool("update", false, "update golden test output files")
 
 func TestHelmRender(t *testing.T) {
-	files, err := os.ReadDir("./test/golden")
-	if err != nil {
-		t.Fatal(err)
-	}
+    files, err := os.ReadDir("./test/golden")
+    if err != nil {
+        t.Fatal(err)
+    }
 
-	for _, f := range files {
-		if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
-			// Render this values.yaml file
-			output := helm.RenderTemplate(t,
-				&helm.Options{
-					ValuesFiles: []string{"test/golden/" + f.Name()},
-				},
-				"./stable/connector",
-				"test",
-				nil,
-			)
+    for _, f := range files {
+        if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
+            // Render this values.yaml file
+            output := helm.RenderTemplate(t,
+                &helm.Options{
+                    ValuesFiles: []string{"test/golden/" + f.Name()},
+                    SetValues: map[string]string{
+                        "versionOverrideForTests": "0.0.0-test",
+                    },
+                },
+                "./stable/connector",
+                "test",
+                nil,
+            )
 
-			goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
-			regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
-			bytes := regex.ReplaceAll([]byte(output), []byte(""))
+            goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
+            regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
+            bytes := regex.ReplaceAll([]byte(output), []byte(""))
 
-			output = fmt.Sprintf("%s\n", string(bytes))
+            output = fmt.Sprintf("%s\n", string(bytes))
 
-			if *update {
-				err := os.WriteFile(goldenFile, []byte(output), 0644)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
+            if *update {
+                err := os.WriteFile(goldenFile, []byte(output), 0644)
+                if err != nil {
+                    t.Fatal(err)
+                }
+            }
 
-			expected, err := os.ReadFile(goldenFile)
-			if err != nil {
-				t.Fatal(err)
-			}
+            expected, err := os.ReadFile(goldenFile)
+            if err != nil {
+                t.Fatal(err)
+            }
 
-			if string(expected) != output {
-				t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
-			}
-		}
+            if string(expected) != output {
+                t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
+            }
+        }
 
-	}
+    }
 }

--- a/golden_test.go
+++ b/golden_test.go
@@ -1,62 +1,62 @@
 package golden
 
 import (
-    "flag"
-    "fmt"
-    "os"
-    "path/filepath"
-    "regexp"
-    "strings"
-    "testing"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
 
-    "github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/helm"
 )
 
 var update = flag.Bool("update", false, "update golden test output files")
 
 func TestHelmRender(t *testing.T) {
-    files, err := os.ReadDir("./test/golden")
-    if err != nil {
-        t.Fatal(err)
-    }
+	files, err := os.ReadDir("./test/golden")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    for _, f := range files {
-        if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
-            // Render this values.yaml file
-            output := helm.RenderTemplate(t,
-                &helm.Options{
-                    ValuesFiles: []string{"test/golden/" + f.Name()},
-                    SetValues: map[string]string{
-                        "versionOverrideForTests": "0.0.0-test",
-                    },
-                },
-                "./stable/connector",
-                "test",
-                nil,
-            )
+	for _, f := range files {
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".golden.yaml") {
+			// Render this values.yaml file
+			output := helm.RenderTemplate(t,
+				&helm.Options{
+					ValuesFiles: []string{"test/golden/" + f.Name()},
+					SetValues: map[string]string{
+						"versionOverrideForTests": "0.0.0-test",
+					},
+				},
+				"./stable/connector",
+				"test",
+				nil,
+			)
 
-            goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
-            regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
-            bytes := regex.ReplaceAll([]byte(output), []byte(""))
+			goldenFile := "test/golden/" + strings.TrimSuffix(f.Name(), filepath.Ext(".yaml")) + ".golden.yaml"
+			regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
+			bytes := regex.ReplaceAll([]byte(output), []byte(""))
 
-            output = fmt.Sprintf("%s\n", string(bytes))
+			output = fmt.Sprintf("%s\n", string(bytes))
 
-            if *update {
-                err := os.WriteFile(goldenFile, []byte(output), 0644)
-                if err != nil {
-                    t.Fatal(err)
-                }
-            }
+			if *update {
+				err := os.WriteFile(goldenFile, []byte(output), 0644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
 
-            expected, err := os.ReadFile(goldenFile)
-            if err != nil {
-                t.Fatal(err)
-            }
+			expected, err := os.ReadFile(goldenFile)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-            if string(expected) != output {
-                t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
-            }
-        }
+			if string(expected) != output {
+				t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
+			}
+		}
 
-    }
+	}
 }

--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -4,4 +4,4 @@ home: https://www.twingate.com
 description: Twingate Connector helm chart
 icon: https://www.twingate.com/twingate.png
 name: connector
-version: 0.1.22
+version: 0.1.23

--- a/stable/connector/templates/_helpers.tpl
+++ b/stable/connector/templates/_helpers.tpl
@@ -28,7 +28,11 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cn.chart" -}}
+{{- if .Values.versionOverrideForTests -}}
+{{- printf "%s-%s" .Chart.Name .Values.versionOverrideForTests | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/connector/templates/_helpers.tpl
+++ b/stable/connector/templates/_helpers.tpl
@@ -28,11 +28,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cn.chart" -}}
-{{- if .Values.versionOverrideForTests -}}
-{{- printf "%s-%s" .Chart.Name .Values.versionOverrideForTests | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/connector/templates/deployment.yaml
+++ b/stable/connector/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: {{ .Chart.Name }}-{{ .Chart.Version }}
+              value: {{ include "cn.chart" . }}
             - name: TWINGATE_URL
               value: "https://{{ required "Network name required" .Values.connector.network }}.{{ .Values.connector.url | default "twingate.com" }}"
               {{- if .Values.connector.dnsServer }}

--- a/test/golden/affinity.golden.yaml
+++ b/test/golden/affinity.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/affinity.golden.yaml
+++ b/test/golden/affinity.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/affinity.golden.yaml
+++ b/test/golden/affinity.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/affinity.golden.yaml
+++ b/test/golden/affinity.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/connector-url.golden.yaml
+++ b/test/golden/connector-url.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.another-twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/connector-url.golden.yaml
+++ b/test/golden/connector-url.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.another-twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/connector-url.golden.yaml
+++ b/test/golden/connector-url.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.another-twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/connector-url.golden.yaml
+++ b/test/golden/connector-url.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.another-twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/default-values.golden.yaml
+++ b/test/golden/default-values.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/default-values.golden.yaml
+++ b/test/golden/default-values.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/default-values.golden.yaml
+++ b/test/golden/default-values.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/default-values.golden.yaml
+++ b/test/golden/default-values.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/env-vars.golden.yaml
+++ b/test/golden/env-vars.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/env-vars.golden.yaml
+++ b/test/golden/env-vars.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/env-vars.golden.yaml
+++ b/test/golden/env-vars.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/env-vars.golden.yaml
+++ b/test/golden/env-vars.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/extraPodDefinitions.golden.yaml
+++ b/test/golden/extraPodDefinitions.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/extraPodDefinitions.golden.yaml
+++ b/test/golden/extraPodDefinitions.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/extraPodDefinitions.golden.yaml
+++ b/test/golden/extraPodDefinitions.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/extraPodDefinitions.golden.yaml
+++ b/test/golden/extraPodDefinitions.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/logAnalytics.golden.yaml
+++ b/test/golden/logAnalytics.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/logAnalytics.golden.yaml
+++ b/test/golden/logAnalytics.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/logAnalytics.golden.yaml
+++ b/test/golden/logAnalytics.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/logAnalytics.golden.yaml
+++ b/test/golden/logAnalytics.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-debug.golden.yaml
+++ b/test/golden/loglevel-debug.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-debug.golden.yaml
+++ b/test/golden/loglevel-debug.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-debug.golden.yaml
+++ b/test/golden/loglevel-debug.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-debug.golden.yaml
+++ b/test/golden/loglevel-debug.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-error.golden.yaml
+++ b/test/golden/loglevel-error.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-error.golden.yaml
+++ b/test/golden/loglevel-error.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-error.golden.yaml
+++ b/test/golden/loglevel-error.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-error.golden.yaml
+++ b/test/golden/loglevel-error.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-info.golden.yaml
+++ b/test/golden/loglevel-info.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-info.golden.yaml
+++ b/test/golden/loglevel-info.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-info.golden.yaml
+++ b/test/golden/loglevel-info.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-info.golden.yaml
+++ b/test/golden/loglevel-info.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-warning.golden.yaml
+++ b/test/golden/loglevel-warning.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-warning.golden.yaml
+++ b/test/golden/loglevel-warning.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-warning.golden.yaml
+++ b/test/golden/loglevel-warning.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/loglevel-warning.golden.yaml
+++ b/test/golden/loglevel-warning.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/resources.golden.yaml
+++ b/test/golden/resources.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/resources.golden.yaml
+++ b/test/golden/resources.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/resources.golden.yaml
+++ b/test/golden/resources.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/resources.golden.yaml
+++ b/test/golden/resources.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/toleration.golden.yaml
+++ b/test/golden/toleration.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.0.0-test
+              value: connector-0.1.22
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/toleration.golden.yaml
+++ b/test/golden/toleration.golden.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -21,6 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
+    helm.sh/chart: major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -48,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/toleration.golden.yaml
+++ b/test/golden/toleration.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ metadata:
   name: test-connector
   labels:
     app.kubernetes.io/name: connector
-    helm.sh/chart: major.minor.patch-test
+    helm.sh/chart: connector-major.minor.patch-test
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: major.minor.patch-test
+              value: connector-major.minor.patch-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL

--- a/test/golden/toleration.golden.yaml
+++ b/test/golden/toleration.golden.yaml
@@ -48,7 +48,7 @@ spec:
             - name: TWINGATE_LABEL_DEPLOYED_BY
               value: helm
             - name: TWINGATE_LABEL_HELM_CHART
-              value: connector-0.1.22
+              value: connector-0.0.0-test
             - name: TWINGATE_URL
               value: "https://test-tenant.twingate.com"
             - name: TWINGATE_LOG_LEVEL


### PR DESCRIPTION
#### What this PR does / why we need it:

Make our helm chart's golden tests less of a hassle:
- We're using  `.Chart.Version` value in our template - specifically we're using the `cn.name` helper:
```
{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
```
- Since the version value changes on (almost) every PR, any chart change will trigger all the golden test snapshots being updated.
- What this fix does is set `cn.name` value to a specific const value during tests so that snapshots wont change on version change - https://github.com/Twingate/helm-charts/pull/37/files#diff-41512ec9e324e19e492871c5fe0d33e6a2506438dc49c2a83f51f9edbc663804


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
