### PR TITLE
Fix validation - allow specifying `url` instead of `network`

### DIFF
--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -4,4 +4,4 @@ home: https://www.twingate.com
 description: Twingate Connector helm chart
 icon: https://www.twingate.com/twingate.png
 name: connector
-version: 0.1.24
+version: 0.1.25

--- a/stable/connector/values.schema.json
+++ b/stable/connector/values.schema.json
@@ -75,7 +75,9 @@
             "title": "The connector Schema",
             "oneOf": [
                 {"required": ["network", "accessToken", "refreshToken"]},
-                {"required": ["network", "existingSecret"]}
+                {"required": ["network", "existingSecret"]},
+                {"required": ["url", "accessToken", "refreshToken"]},
+                {"required": ["url", "existingSecret"]}
             ],
             "properties": {
                 "logLevel": {


### PR DESCRIPTION
#### What this PR does / why we need it:

We allow specifying either `connector.network` or `connector.url` but not both.
Validation right now blocks specifying `connector.url`

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
