### PR TITLE
fix: Readiness probes `initialDelaySeconds` `null` value

### DIFF
--- a/stable/connector/Chart.yaml
+++ b/stable/connector/Chart.yaml
@@ -4,4 +4,4 @@ home: https://www.twingate.com
 description: Twingate Connector helm chart
 icon: https://www.twingate.com/twingate.png
 name: connector
-version: 0.1.30
+version: 0.1.31

--- a/stable/connector/values.yaml
+++ b/stable/connector/values.yaml
@@ -111,7 +111,7 @@ readinessProbe:
     command:
     - /connectorctl
     - health
-  initialDelaySeconds:
+  initialDelaySeconds: 5
   periodSeconds: 5
 
 livenessProbe:

--- a/test/golden/affinity.golden.yaml
+++ b/test/golden/affinity.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/connector-url.golden.yaml
+++ b/test/golden/connector-url.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/default-values.golden.yaml
+++ b/test/golden/default-values.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/env-vars.golden.yaml
+++ b/test/golden/env-vars.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/extraPodDefinitions.golden.yaml
+++ b/test/golden/extraPodDefinitions.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/image-pull-secrets.golden.yaml
+++ b/test/golden/image-pull-secrets.golden.yaml
@@ -49,7 +49,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/logAnalytics.golden.yaml
+++ b/test/golden/logAnalytics.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/loglevel-debug.golden.yaml
+++ b/test/golden/loglevel-debug.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/loglevel-error.golden.yaml
+++ b/test/golden/loglevel-error.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/loglevel-info.golden.yaml
+++ b/test/golden/loglevel-info.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/loglevel-warning.golden.yaml
+++ b/test/golden/loglevel-warning.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/podSecurityContext.golden.yaml
+++ b/test/golden/podSecurityContext.golden.yaml
@@ -50,7 +50,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/priority-class.golden.yaml
+++ b/test/golden/priority-class.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/resources.golden.yaml
+++ b/test/golden/resources.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/securityContext.golden.yaml
+++ b/test/golden/securityContext.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/toleration.golden.yaml
+++ b/test/golden/toleration.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:

--- a/test/golden/topology.golden.yaml
+++ b/test/golden/topology.golden.yaml
@@ -47,7 +47,7 @@ spec:
               command:
               - /connectorctl
               - health
-            initialDelaySeconds: null
+            initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             exec:


### PR DESCRIPTION
#### What this PR does / why we need it:
- We added readiness probes in this [PR](https://github.com/Twingate/helm-charts/pull/55), however the `readinessProbe.initialDelaySeconds` is not set correctly. This PR fixes it and sets the value to 5

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped